### PR TITLE
BugzID: 3224 - CMS: Can't insert images into default Body part

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-clipped-extension (2.0.10)
+    trusty-clipped-extension (2.0.11)
       acts_as_list (~> 0.4.0)
       cocaine (~> 0.5)
       paperclip (~> 4.2)

--- a/app/assets/javascripts/admin/assets.js
+++ b/app/assets/javascripts/admin/assets.js
@@ -25,7 +25,7 @@ Assets = {
     $('a.insert_asset').off('click').click(function(e){
       e.preventDefault();
       var part_name = $("a.tab.here").children('span').html();
-      if (part_name.indexOf(' ')) part_name = part_name.replace(' ', '-');
+      if (part_name.indexOf(' ')) part_name = part_name.replace(' ', '-').toLowerCase();
       part_name = part_name.replace('_', '-');
       var part_id = 'part_' + part_name + '_content';
       var tag_parts = $(this).attr('rel').split('_');

--- a/lib/trusty-clipped-extension.rb
+++ b/lib/trusty-clipped-extension.rb
@@ -1,5 +1,5 @@
 module TrustyCmsClippedExtension
-  VERSION     = "2.0.10"
+  VERSION     = "2.0.11"
   SUMMARY     = %q{Assets for TrustyCms CMS}
   DESCRIPTION = %q{Asset-management derived from Keith Bingman's Paperclipped extension.}
   URL         = "https://github.com/pgharts/trusty-clipped-extension"


### PR DESCRIPTION
On line 95 of assets.js, the part_id is being passed and ckeditor is looking for a mode. If the part_id is capitalized, for some reason this is causing a failure for ckeditor. I wasn't able to track down the specific issue, but I added a toLowerCase() on line 28 to correct this.