### PR TITLE
Register 2.0.15 - lock Kraken to use lossy compression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 
 language: ruby
 rvm:
-  - 2.1.5
+  - 2.3.1
 
 services: mysql
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    trusty-clipped-extension (2.0.14)
+    trusty-clipped-extension (2.0.15)
       acts_as_list (~> 0.4.0)
       cocaine (~> 0.5)
       kraken-io
@@ -103,8 +103,8 @@ GEM
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     ffi (1.9.10)
-    globalid (0.3.7)
-      activesupport (>= 4.1.0)
+    globalid (0.4.0)
+      activesupport (>= 4.2.0)
     haml (4.0.7)
       tilt
     haml-rails (0.9.0)
@@ -134,10 +134,10 @@ GEM
       multipart-post
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.19)
+    libv8 (3.16.14.19-x86_64-darwin-16)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    mail (2.6.4)
+    mail (2.6.5)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (3.0)
@@ -228,7 +228,7 @@ GEM
       rspec-mocks (~> 3.0.0)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
-    ruby_parser (3.8.4)
+    ruby_parser (3.9.0)
       sexp_processor (~> 4.1)
     sass (3.4.21)
     sass-rails (5.0.4)
@@ -237,7 +237,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sexp_processor (4.8.0)
+    sexp_processor (4.9.0)
     slop (3.6.0)
     sprockets (2.12.4)
       hike (~> 1.2)

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -1,21 +1,21 @@
 class Admin::AssetsController < Admin::ResourceController
   paginate_models(:per_page => 50)
   COMPRESS_FILE_TYPE = ["image/jpeg", "image/png", "image/gif", "image/svg+xml"]
-  
+
   def index
     assets = Asset.order("created_at DESC")
     @page = Page.find(params[:page_id]) if params[:page_id]
 
     @term = params[:search] || ''
     assets = assets.matching(@term) if @term && !@term.blank?
-    
+
     @types = params[:filter] ? params[:filter].split(",") : []
     if @types.include?('all')
       params[:filter] = nil
     elsif @types.any?
       assets = assets.of_types(@types)
     end
-    
+
     @assets = paginated? ? assets.paginate(pagination_parameters) : assets.all
     respond_to do |format|
 
@@ -28,7 +28,7 @@ class Admin::AssetsController < Admin::ResourceController
       }
     end
   end
-  
+
   def create
     @assets, @page_attachments = [], []
     params[:asset][:asset].to_a.each do |uploaded_asset|
@@ -46,11 +46,11 @@ class Admin::AssetsController < Admin::ResourceController
     end
     if params[:for_attachment]
       render :partial => 'admin/page_attachments/attachment', :collection => @page_attachments
-    else 
+    else
       response_for :create
     end
   end
-  
+
   def refresh
     if params[:id]
       @asset = Asset.find(params[:id])
@@ -61,7 +61,7 @@ class Admin::AssetsController < Admin::ResourceController
       render
     end
   end
-  
+
   only_allow_access_to :regenerate,
     :when => [:admin],
     :denied_url => { :controller => 'admin/assets', :action => 'index' },
@@ -75,9 +75,9 @@ class Admin::AssetsController < Admin::ResourceController
 
 private
   def compress(uploaded_asset)
-    data = $kraken.upload(uploaded_asset.tempfile.path)
+    data = $kraken.upload(uploaded_asset.tempfile.path, 'lossy' => true)
     File.write(uploaded_asset.tempfile, open(data.kraked_url).read, { :mode => 'wb' })
     uploaded_asset
   end
-  
+
 end

--- a/lib/trusty-clipped-extension.rb
+++ b/lib/trusty-clipped-extension.rb
@@ -1,5 +1,5 @@
 module TrustyCmsClippedExtension
-  VERSION     = "2.0.14"
+  VERSION     = "2.0.15"
   SUMMARY     = %q{Assets for TrustyCms CMS}
   DESCRIPTION = %q{Asset-management derived from Keith Bingman's Paperclipped extension.}
   URL         = "https://github.com/pgharts/trusty-clipped-extension"


### PR DESCRIPTION
When you decide to sacrifice just a small amount of image quality (usually unnoticeable to the human eye), you will be able to save up to 90% of the initial file weight. Lossy optimization will give you outstanding results with just a fraction of image quality loss.

To use lossy optimizations simply set "lossy" => true in your request:

kraken.upload('/path/to/image/file.jpg', 'lossy' => true)