### PR TITLE
BugzID: 4407 - CMS Upload to Production broken

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    trusty-clipped-extension (3.1.0)
+    trusty-clipped-extension (3.1.1)
       acts_as_list (~> 0.9.5)
       cocaine (~> 0.5.8)
       kraken-io
@@ -58,7 +58,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    acts_as_list (0.9.7)
+    acts_as_list (0.9.9)
       activerecord (>= 3.0)
     acts_as_tree (2.6.1)
       activerecord (>= 3.0.0)
@@ -100,7 +100,7 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.0.5)
-    css_parser (1.5.0)
+    css_parser (1.6.0)
       addressable
     database_cleaner (1.5.3)
     delocalize (0.4.0)
@@ -115,9 +115,9 @@ GEM
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     ffi (1.9.18)
-    globalid (0.4.0)
+    globalid (0.4.1)
       activesupport (>= 4.2.0)
-    haml (5.0.2)
+    haml (5.0.4)
       temple (>= 0.8.0)
       tilt
     haml-rails (1.0.0)
@@ -147,7 +147,7 @@ GEM
       multipart-post
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.19-x86_64-darwin-16)
+    libv8 (3.16.14.19)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -159,10 +159,10 @@ GEM
     mimemagic (0.3.2)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
-    multi_json (1.12.1)
+    multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
-    mysql2 (0.4.8)
+    mysql2 (0.4.9)
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
@@ -186,7 +186,7 @@ GEM
       pry (~> 0.10)
     public_suffix (2.0.5)
     rack (2.0.3)
-    rack-cache (1.7.0)
+    rack-cache (1.7.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -257,7 +257,7 @@ GEM
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -269,7 +269,7 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    trusty-cms (3.1.0)
+    trusty-cms (3.1.3)
       RedCloth (~> 4.3.2)
       acts_as_tree (~> 2.6.1)
       bundler (~> 1.7)
@@ -326,4 +326,4 @@ DEPENDENCIES
   trustygems (~> 0.2.0)
 
 BUNDLED WITH
-   1.15.3
+   1.16.0.pre.2

--- a/app/controllers/admin/assets_controller.rb
+++ b/app/controllers/admin/assets_controller.rb
@@ -47,7 +47,7 @@ class Admin::AssetsController < Admin::ResourceController
     if asset_params[:for_attachment]
       render :partial => 'admin/page_attachments/attachment', :collection => @page_attachments
     else
-      response_for :create
+      render :partial => 'admin/page_attachments/attachment'
     end
   end
 

--- a/lib/trusty-clipped-extension.rb
+++ b/lib/trusty-clipped-extension.rb
@@ -1,5 +1,5 @@
 module TrustyCmsClippedExtension
-  VERSION     = "3.1.0"
+  VERSION     = "3.1.1"
   SUMMARY     = %q{Assets for TrustyCms CMS}
   DESCRIPTION = %q{Asset-management derived from Keith Bingman's Paperclipped extension.}
   URL         = "https://github.com/pgharts/trusty-clipped-extension"


### PR DESCRIPTION
It appears response_for :create is deprecated and this needed to be changed to render the partial with the asset information